### PR TITLE
Add functionality to always fetch the latest master build

### DIFF
--- a/make_libreoffice_appimage
+++ b/make_libreoffice_appimage
@@ -156,6 +156,42 @@ case $# in
         ;;
 esac
 
+declare -A master_builds
+
+function todate() {
+    # change the date to Unix timestamp
+    local datestring="TZ=\"UTC\" ${1}"
+    date -d "$datestring" +%s
+}
+
+function newestmaster() {
+    # Compare the dates as timestamps to find the newest one
+    # Access associative array with a name reference
+    # Key is relative path to file, value is date
+    local -n ar=$1
+    local max=0
+    local filepath=""    
+    for i in "${!ar[@]}" ; do
+        timestamp=$(todate "${ar[$i]}")
+        (("$timestamp" > max)) && max="$timestamp" && filepath="$i"
+    done
+    echo "$filepath"
+}
+
+function filtermasters() {
+    # Read a page listing the actually available builds
+    local current_masters=$(wget -q "https://dev-builds.libreoffice.org/daily/master/current.html" -O -)
+    # Put all the Linux build links into an array, but filter out any debug or rpm archives
+    mapfile -t master_links < <( grep -oP -e '<a href="\.\/Linux.*</a>' <<< "$current_masters" | grep -vE 'dbg|rpm\.tar\.gz' )
+    # Add relative file paths and dates into an associative array
+    for link in "${master_links[@]}"; do
+        key=$(grep -oP -e '(?<=<a href="\.\/)Linux.*(?=">)' <<< "$link")
+        value=$(grep -oP -e "(?<=<a href=\"\.\/${key}\">).*(?=<\/a>)" <<< "$link")
+        master_builds[$key]=$value
+    done
+    newestmaster master_builds
+}
+
 pathVersion=$1
 arch="${2:-x86-64}"
 language="${3:-N}"
@@ -260,10 +296,12 @@ elif [[ $pathVersion == *"still"* ]] ; then
     path="https://download.documentfoundation.org/libreoffice/stable/${nrVersion}/deb/${pathArch}/"
     package="LibreOffice_${nrVersion}_Linux_${arch}_deb.tar.gz"
 elif [[ $pathVersion == *"daily"* ]] ; then
-    path="http://dev-builds.libreoffice.org/daily/master/Linux-rpm_deb-${pathArch}@70-TDF/current/"
-    package=$(wget -q "$path" -O - | grep -o -e ">mas.*Linux_x86-64_deb.tar.gz" | cut -d ">" -f 2)
-    tmpVersion1=$(echo "$package" | cut -d "_" -f 4)
-    tmpVersion2=$(echo "$package" | cut -d "_" -f 1 | cut -d "~" -f 2)
+    path="https://dev-builds.libreoffice.org/daily/master/"
+    package=$(filtermasters)
+    tmpVersion1="${package%_Linux_x86-64_deb.tar.gz}"
+    tmpVersion1="${tmpVersion1##*LibreOfficeDev_}"
+    tmpVersion2="${package%_[[:digit:]][[:digit:]].*}"
+    tmpVersion2="${tmpVersion2##*master~}"
     nrVersion=$tmpVersion1"_"$tmpVersion2
 else
     if [[ $pathVersion == "3."* ]] ; then

--- a/make_libreoffice_appimage
+++ b/make_libreoffice_appimage
@@ -337,26 +337,31 @@ cd ./$APP || exit
 wget -c "$LibODownloadLink"
 
 if [[ $language != "N" ]] ; then
+    if [[ $pathVersion == *"daily"* ]] ; then
+        nameStart="${package%.tar.gz}_langpack_"
+    else
+        nameStart="LibreOffice_${nrVersion}_Linux_${arch}_deb_langpack_"
+    fi
     if [[ $language == *"standard"* ]] ; then
-	    for element in ${standard[*]};
+        for element in ${standard[*]};
             do
-               langPackage="LibreOffice_${nrVersion}_Linux_${arch}_deb_langpack_$element.tar.gz"
+               langPackage="$nameStart$element.tar.gz"
                wget -c "$path$langPackage"
             done
     elif [[ $language == *"full"* ]] ; then
-	    for element in ${full[*]};
+        for element in ${full[*]};
             do
-               langPackage="LibreOffice_${nrVersion}_Linux_${arch}_deb_langpack_$element.tar.gz"
+               langPackage="$nameStart$element.tar.gz"
                wget -c "$path$langPackage"
             done
     else
-            if [[ $pathVersion == "3."* ]] ; then
-		langPackage="LibO_${nrVersion}_Linux_${arch}_langpack-deb_${language}.tar.gz"
-		wget -c "$path$langPackage"
-            else
-		langPackage="LibreOffice_${nrVersion}_Linux_${arch}_deb_langpack_${language}.tar.gz"
-                wget -c "$path$langPackage"
-	    fi
+        if [[ $pathVersion == "3."* ]] ; then
+            langPackage="LibO_${nrVersion}_Linux_${arch}_langpack-deb_${language}.tar.gz"
+            wget -c "$path$langPackage"
+        else
+            langPackage="$nameStart${language}.tar.gz"
+            wget -c "$path$langPackage"
+        fi
     fi
 fi
 


### PR DESCRIPTION
Now there is no need to hard-code the Tinderbox number.
Uses an associative array, which requires Bash 4.3, but I guess the point
of the script is not to be POSIX-compatible.
The arch argument is irrelevant for master, because there are no 32-bit builds
anymore.