### PR TITLE
Fix downloadarchive link

### DIFF
--- a/make_libreoffice_appimage
+++ b/make_libreoffice_appimage
@@ -328,7 +328,7 @@ else
 	package="LibO_${nrVersion}_Linux_${arch}_install-deb_en-US.tar.gz"
     else
         nrVersion=$libreVersion
-	path="https://download.documentfoundation.org/libreoffice/old/${nrVersion}/deb/${pathArch}/"
+	path="https://downloadarchive.documentfoundation.org/libreoffice/old/${nrVersion}/deb/${pathArch}/"
 	package="LibreOffice_${nrVersion}_Linux_${arch}_deb.tar.gz"
     fi
 fi


### PR DESCRIPTION
When the first parameter is a specific version number (e.g. 5.3.7.2) the
script did not work because the download link was broken in commit
00c814d.  This commit fixes the link.