### PR TITLE
 Customizable selection of help and language packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The script takes 6 parameters:
    - `'<single>'`:  one single extra language code out of those supported by the project (for full list see above), f.e. `it`;
    - `'N'`:  no extra language at all; the package will contain support for the default language only (which is `en-US`).
 
-4. **Fourth:** request to package (or not) the offline help into the bundle. This the offline help language will be the same as selected for the third parameter above:
+4. **Fourth:** request to package (or not) the offline help into the bundle. For `'standard'` language pack, this is only for the first language, else the offline help language will be the same as selected for the third parameter above:
    - `'Y'`:  yes, embed the offline help in the AppImage;
    - `'N'`:  no, do NOT embed the offline help in the AppImage.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The script takes 6 parameters:
    This parameter can be 'x86' (for 32-bit) or 'x86-64' (for 64-bit).
 
 3. **Third:** request the language pack(s) you want to use with LibreOffice. The following values may be submitted:
-   - `'standard'`: creates a package with a set of pre-defined languages, namely: *nl, en-GB, fr, de*;
+   - `'standard'`: creates a package with a set of pre-defined languages, namely: *en-GB, it, ar, zh-CN, zh-TW, fr, de, ja, ko, pt, pt-BR, es, ru*;
    - `'full'`:  creates a package with ALL the languages supported by the project, namely: *af, am, ar, as, ast, be, bg, bn-IN, bn, bo, br, brx, bs, ca-valencia, ca, cs, cy, da, de, dgo, dz, el, en-GB, en-ZA, eo, es, et, eu, fa, fi, fr, ga, gd, gl, gu, gug, he, hi, hr, hsb, hu, id, is, it, ja, ka, kk, km, kmr, kn, ko, kok, ks, lb, lo, lt, lv, mai, mk, ml, mn, mni, mr, my, nb, ne, nl, nn, nr, nso, oc, om, or, pa-IN, pl, pt-BR, pt, qtz, ro, ru, rw, sa-IN, sat, sd, si, sid, sk, sl, sq, sr-Latn, sr, ss, st, sv, sw-TZ, ta, te, tg, th, tn, tr, ts, tt, ug, uk, uz, ve, vec, vi, xh, zh-CN, zh-TW, zu*;
    - `'<custom>'`:  one or more comma separated language codes out of those supported by the project (for full list see above), f.e. `it` or `de,es`;
    - `'N'`:  no extra language at all; the package will contain support for the default language only (which is `en-US`).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The script takes 6 parameters:
    This parameter can be 'x86' (for 32-bit) or 'x86-64' (for 64-bit).
 
 3. **Third:** request the language pack(s) you want to use with LibreOffice. The following values may be submitted:
-   - `'standard'`: creates a package with a set of pre-defined languages, namely: *en-GB, it, ar, zh-CN, zh-TW, fr, de, ja, ko, pt, pt-BR, es, ru*;
+   - `'standard'`: creates a package with a set of pre-defined languages, namely: *nl, en-GB, fr, de*;
    - `'full'`:  creates a package with ALL the languages supported by the project, namely: *af, am, ar, as, ast, be, bg, bn-IN, bn, bo, br, brx, bs, ca-valencia, ca, cs, cy, da, de, dgo, dz, el, en-GB, en-ZA, eo, es, et, eu, fa, fi, fr, ga, gd, gl, gu, gug, he, hi, hr, hsb, hu, id, is, it, ja, ka, kk, km, kmr, kn, ko, kok, ks, lb, lo, lt, lv, mai, mk, ml, mn, mni, mr, my, nb, ne, nl, nn, nr, nso, oc, om, or, pa-IN, pl, pt-BR, pt, qtz, ro, ru, rw, sa-IN, sat, sd, si, sid, sk, sl, sq, sr-Latn, sr, ss, st, sv, sw-TZ, ta, te, tg, th, tn, tr, ts, tt, ug, uk, uz, ve, vec, vi, xh, zh-CN, zh-TW, zu*;
    - `'<single>'`:  one single extra language code out of those supported by the project (for full list see above), f.e. `it`;
    - `'N'`:  no extra language at all; the package will contain support for the default language only (which is `en-US`).

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ The script takes 6 parameters:
 3. **Third:** request the language pack(s) you want to use with LibreOffice. The following values may be submitted:
    - `'standard'`: creates a package with a set of pre-defined languages, namely: *nl, en-GB, fr, de*;
    - `'full'`:  creates a package with ALL the languages supported by the project, namely: *af, am, ar, as, ast, be, bg, bn-IN, bn, bo, br, brx, bs, ca-valencia, ca, cs, cy, da, de, dgo, dz, el, en-GB, en-ZA, eo, es, et, eu, fa, fi, fr, ga, gd, gl, gu, gug, he, hi, hr, hsb, hu, id, is, it, ja, ka, kk, km, kmr, kn, ko, kok, ks, lb, lo, lt, lv, mai, mk, ml, mn, mni, mr, my, nb, ne, nl, nn, nr, nso, oc, om, or, pa-IN, pl, pt-BR, pt, qtz, ro, ru, rw, sa-IN, sat, sd, si, sid, sk, sl, sq, sr-Latn, sr, ss, st, sv, sw-TZ, ta, te, tg, th, tn, tr, ts, tt, ug, uk, uz, ve, vec, vi, xh, zh-CN, zh-TW, zu*;
-   - `'<single>'`:  one single extra language code out of those supported by the project (for full list see above), f.e. `it`;
+   - `'<custom>'`:  one or more comma separated language codes out of those supported by the project (for full list see above), f.e. `it` or `de,es`;
    - `'N'`:  no extra language at all; the package will contain support for the default language only (which is `en-US`).
 
-4. **Fourth:** request to package (or not) the offline help into the bundle. For `'standard'` language pack, this is only for the first language, else the offline help language will be the same as selected for the third parameter above:
-   - `'Y'`:  yes, embed the offline help in the AppImage;
+4. **Fourth:** request to package (or not) offline help into the bundle.:
+   - `'Y'`:  yes, embed the offline help in the AppImage for the same languages as selected for the third parameter above;
+   - `<custom>`:  one or more comma separated language codes out of those supported by the project (for full list see above), f.e. `it` or `de,es`;
    - `'N'`:  no, do NOT embed the offline help in the AppImage.
 
 5. **Fifth:**  specify if you want (or not) to be able to make the package updateable. (This additionally creates a *zsync* file, which is used to handle "differential" downloads, so an update does not have to fetch a *complete* AppImage file, but only those byte-ranges which have changed). For this option to work, the [zsync-curl](https://github.com/AppImage/zsync-curl) tool must be present on the system. Possible values are:

--- a/make_libreoffice_appimage
+++ b/make_libreoffice_appimage
@@ -18,6 +18,7 @@ argv5="${5}"
 argv6="${6}"
 argv7="${7}"
 
+everylang="af|am|ar|as|ast|be|bg|bn-IN|bn|bo|br|brx|bs|ca-valencia|ca|cs|cy|da|de|dgo|dz|el|en-GB|en-ZA|eo|es|et|eu|fa|fi|fr|ga|gd|gl|gu|gug|he|hi|hr|hsb|hu|id|is|it|ja|ka|kk|km|kmr|kn|ko|kok|ks|lb|lo|lt|lv|mai|mk|ml|mn|mni|mr|my|nb|ne|nl|nn|nr|nso|oc|om|or|pa-IN|pl|pt-BR|pt|qtz|ro|ru|rw|sa-IN|sat|sd|si|sid|sk|sl|sq|sr-Latn|sr|ss|st|sv|sw-TZ|ta|te|tg|th|tn|tr|ts|tt|ug|uk|uz|ve|vec|vi|xh|zh-CN|zh-TW|zu"
 # Describe usage:
 usage() {
     echo ""
@@ -34,12 +35,13 @@ usage() {
     echo "             <arch>:      'x86':   package 32-bit binaries"
     echo "                       'x86-64':   package 64-bit binaries"
     echo ""
-    echo "             <lang>: 'standard':   includes nl, en-GB, fr, de language-packs"
+    echo "             <lang>: 'standard':   includes en-GB, it, ar, zh-CN, zh-TW, fr, de, ja, ko, pt, pt-BR, es, ru language-packs"
     echo "                         'full':   includes all available language-packs (for some releases more than 113 different ones!)"
     echo "                            'N':   no extra language-pack (LibreOffice comes with default 'en-US')"
-    echo "                       <single>:   includes the named language-pack (for example 'de', 'it' or 'es')"
+    echo "                       <custom>:   includes one or more comma separated language-packs (for example 'de' or 'it,es')"
     echo ""
-    echo "             <help-yesno>:  'Y' or 'N' (Yes/No to include online help -- depends on the previous '<lang>' parameter)"
+    echo "             <help-yesno>:  'Y' or 'N' (Yes/No to include online help for each language pack installed for the previous '<lang>' parameter)"
+    echo "                       <custom>:   includes help for one or more comma separated languages (for example 'de' or 'it,es')"
     echo ""
     echo "             <zsync-yesno>: 'Y' or 'N' (Yes/No to include capability for updating the AppImage with the help of 'AppImageUpdate')"
     echo ""
@@ -93,28 +95,62 @@ check() {   # This is not a complete, but only a limited sanity check of the inp
         N)
             echo "    -- without any extra localization language;"
             ;;
-        af|am|ar|as|ast|be|bg|bn-IN|bn|bo|br|brx|bs|ca-valencia|ca|cs|cy|da|de|dgo|dz|el|en-GB|en-ZA|eo|es|et|eu|fa|fi|fr|ga|gd|gl|gu|gug|he|hi|hr|hsb|hu|id|is|it|ja|ka|kk|km|kmr|kn|ko|kok|ks|lb|lo|lt|lv|mai|mk|ml|mn|mni|mr|my|nb|ne|nl|nn|nr|nso|oc|om|or|pa-IN|pl|pt-BR|pt|qtz|ro|ru|rw|sa-IN|sat|sd|si|sid|sk|sl|sq|sr-Latn|sr|ss|st|sv|sw-TZ|ta|te|tg|th|tn|tr|ts|tt|ug|uk|uz|ve|vec|vi|xh|zh-CN|zh-TW|zu)
+        "$everylang")
             echo "    -- with localization language \"${argv3}\";"
             ;;
         *)
-            echo "==> Wrong or unsupported language request ${argv3} in argument no.3. <=="
-            echo "For correct usage of ${argv0} please see below:"
-            echo ""
-            usage
-            exit 0
+            if [ -z "$argv3" ]
+            then
+                echo "==> Wrong or unsupported language request '${argv3}' in argument no.3. <=="
+                echo "For correct usage of ${argv0} please see below:"
+                echo ""
+                usage
+                exit 0
+            fi
+            for lang in ${argv3//,/ }
+            do
+                for available in ${everylang//|/ }
+                do
+                    [ "$lang" = "$available" ] && continue 2
+                done
+                echo "==> Wrong or unsupported language request '${lang}' in argument no.3. <=="
+                echo "For correct usage of ${argv0} please see below:"
+                echo ""
+                usage
+                exit 0
+            done
+            echo "    -- with localization language(s) \"${argv3}\";"
             ;;
     esac
     case $argv4 in
         Y|N)
             # Do nothing, accepted!
-            echo "    -- include online help = \"${argv4}\";"
+            echo "    -- include offline help = \"${argv4}\";"
             ;;
         *)
-            echo "==> Wrong argument ${argv4} at position no.4! (Must be either 'Y' or 'N' to include offline help or not... <=="
-            echo "For correct usage of ${argv0} please see below:"
-            echo ""
-            usage
-            exit 0
+            if [ -z "$argv4" ]
+            then
+                echo "==> Wrong or unsupported help language request '${argv4}' in argument no.4. <=="
+                echo "==> Must be either 'Y', 'N' or a comma separated list of languages to include <=="
+                echo "For correct usage of ${argv0} please see below:"
+                echo ""
+                usage
+                exit 0
+            fi
+            for helplang in ${argv4//,/ }
+            do
+                for available in ${everylang//|/ }
+                do
+                    [ "$helplang" = "$available" ] && continue 2
+                done
+                echo "==> Wrong or unsupported help language request '${helplang}' in argument no.4. <=="
+                echo "==> Must be either 'Y', 'N' or a comma separated list of languages to include <=="
+                echo "For correct usage of ${argv0} please see below:"
+                echo ""
+                usage
+                exit 0
+            done
+            echo "    -- include offline help language(s) \"${argv4}\";"
             ;;
     esac
     case $argv5 in
@@ -220,8 +256,26 @@ optPortable="${7:-Y}"
 linkZsync=""
 gpgPass=""
 
-standard=(nl en-GB fr de) #(en-GB it ar zh-CN zh-TW fr de ja ko pt pt-BR es ru)
-full=(af am ar as ast be bg bn-IN bn bo br brx bs ca-valencia ca cs cy da de dgo dz el en-GB en-ZA eo es et eu fa fi fr ga gd gl gu gug he hi hr hsb hu id is it ja ka kk km kmr kn ko kok ks lb lo lt lv mai mk ml mn mni mr my nb ne nl nn nr nso oc om or pa-IN pl pt-BR pt qtz ro ru rw sa-IN sat sd si sid sk sl sq sr-Latn sr ss st sv sw-TZ ta te tg th tn tr ts tt ug uk uz ve vec vi xh zh-CN zh-TW zu)
+if [[ $language == *"standard"* ]] ; then
+    languages=(en-GB it ar zh-CN zh-TW fr de ja ko pt pt-BR es ru)
+elif [[ $language == *"full"* ]] ; then
+    languages=(${everylang//|/ })
+elif [[ $language != "N" ]] ; then
+    languages=(${argv3//,/ })
+        # avoid long language lists in VERSION; and commas like in "fr,de"
+        # cause "LibreOffice-$VERSION.AppImage --appimage-mount" to fail
+    [ "${#languages[@]}" -le 4 ] && language="${language//,/_}" || language="custom"
+else
+    languages=()
+fi
+
+if [[ $optHelp == *"Y"* ]] ; then
+    helplanguages=("${languages[@]}")
+elif [[ $optHelp != "N" ]] ; then
+    helplanguages=(${argv4//,/ })
+else
+    helplanguages=()
+fi
 
 if [[ $arch == *"x86-64"* ]] ; then
     pathArch="x86_64"
@@ -335,7 +389,7 @@ fi
 
 LibODownloadLink=$path$package
 
-if [[ $optHelp == *"Y"* ]] ; then
+if [[ $optHelp != "N" ]] ; then
 	 if [[ $language != "N" ]] ; then
 	   VERSION="${nrVersion}.$language.help"
   	 else
@@ -360,56 +414,54 @@ if [[ $language != "N" ]] ; then
     else
         langStart="LibreOffice_${nrVersion}_Linux_${arch}_deb_langpack_"
     fi
-    if [[ $language == *"standard"* ]] ; then
-        for element in ${standard[*]}; do
-            langPackage="$langStart$element.tar.gz"
-            wget -c "$path$langPackage"
-        done
-    elif [[ $language == *"full"* ]] ; then
-        for element in ${full[*]}; do
+    if [[ $language == *"standard"* || $language == *"full"* ]] ; then
+        for element in ${languages[*]}; do
             langPackage="$langStart$element.tar.gz"
             wget -c "$path$langPackage"
         done
     else
         if [[ $pathVersion == "3."* ]] ; then
-            langPackage="LibO_${nrVersion}_Linux_${arch}_langpack-deb_${language}.tar.gz"
-            wget -c "$path$langPackage"
+            for element in ${languages[*]}; do
+                langPackage="LibO_${nrVersion}_Linux_${arch}_langpack-deb_${element}.tar.gz"
+                wget -c "$path$langPackage"
+            done
         else
-            langPackage="$langStart${language}.tar.gz"
-            wget -c "$path$langPackage"
+            for element in ${languages[*]}; do
+                langPackage="$langStart${element}.tar.gz"
+                wget -c "$path$langPackage"
+            done
         fi
     fi
 fi
 
-if [[ $optHelp == *"Y"* ]] ; then
+if [[ $optHelp != "N" ]] ; then
     if [[ $pathVersion == *"daily"* ]] ; then
         helpStart="${package%.tar.gz}_helppack_"
     else
         helpStart="LibreOffice_${nrVersion}_Linux_${arch}_deb_helppack_"
     fi
-    if [[ $language == *"standard"* ]] ; then
-         for element in ${standard[0]}; do  #help for 1st language only # WAS: for element in ${standard[*]}; do
-            helpPackage="$helpStart$element.tar.gz"
-            wget -c "$path$helpPackage"
-         done
-    elif [[ $language == *"full"* ]] ; then
-         for element in ${full[*]}; do
+    if [[ $language == *"standard"* || $language == *"full"* ]] ; then
+         for element in ${helplanguages[*]}; do
             helpPackage="$helpStart$element.tar.gz"
             wget -c "$path$helpPackage"
          done
     else
         if [[ $pathVersion == "3."* ]] ; then
-            if [[ $language != "N" ]] ; then
-                helpPackage="LibO_${nrVersion}_Linux_${arch}_helppack-deb_${language}.tar.gz"
-                wget -c "$path$helpPackage"
+            if [[ "${#helplanguages[@]}" != "0" ]] ; then
+                for element in ${helplanguages[*]}; do
+                    helpPackage="LibO_${nrVersion}_Linux_${arch}_helppack-deb_${element}.tar.gz"
+                    wget -c "$path$helpPackage"
+                done
             else
                 helpPackage="LibO_${nrVersion}_Linux_${arch}_helppack-deb_en-US.tar.gz"
                 wget -c "$path$helpPackage"
             fi
         else
-            if [[ $language != "N" ]] ; then
-                helpPackage="$helpStart${language}.tar.gz"
-                wget -c "$path$helpPackage"
+            if [[ "${#helplanguages[@]}" != "0" ]] ; then
+                for element in ${helplanguages[*]}; do
+                    helpPackage="$helpStart${element}.tar.gz"
+                    wget -c "$path$helpPackage"
+                done
             else
                 helpPackage="${helpStart}en-US.tar.gz"
                 wget -c "$path$helpPackage"
@@ -462,13 +514,13 @@ if [[ $optSync == "N" ]] ; then
 	VERSION=$VERSION ./appimagetool -v ./$APP.AppDir/
 else
     if [[ $language == "N" ]] ; then
-    	if [[ $optHelp == "Y" ]] ; then
+    	if [[ $optHelp != "N" ]] ; then
     		VERSION="$pathVersion"."help" ./appimagetool -u "zsync|"$linkZsync$APP"-"$pathVersion".help.AppImage.zsync" -v ./$APP.AppDir/
         else
         	VERSION="$pathVersion" ./appimagetool -u "zsync|"$linkZsync$APP"-"$pathVersion".AppImage.zsync" -v ./$APP.AppDir/
         fi
     else
-    	if [[ $optHelp == *"Y"* ]] ; then
+    	if [[ $optHelp != "N" ]] ; then
         	VERSION="$pathVersion"."$language"."help" ./appimagetool -u "zsync|"$linkZsync$APP"-"$pathVersion"."$language".help.AppImage.zsync" -v ./$APP.AppDir/
         else
         	VERSION="$pathVersion"."$language" ./appimagetool -u "zsync|"$linkZsync$APP"-"$pathVersion"."$language".AppImage.zsync" -v ./$APP.AppDir/

--- a/make_libreoffice_appimage
+++ b/make_libreoffice_appimage
@@ -34,7 +34,7 @@ usage() {
     echo "             <arch>:      'x86':   package 32-bit binaries"
     echo "                       'x86-64':   package 64-bit binaries"
     echo ""
-    echo "             <lang>: 'standard':   includes en-GB, it, ar, zh-CN, zh-TW, fr, de, ja, ko, pt, pt-BR, es, ru language-packs"
+    echo "             <lang>: 'standard':   includes nl, en-GB, fr, de language-packs"
     echo "                         'full':   includes all available language-packs (for some releases more than 113 different ones!)"
     echo "                            'N':   no extra language-pack (LibreOffice comes with default 'en-US')"
     echo "                       <single>:   includes the named language-pack (for example 'de', 'it' or 'es')"
@@ -220,7 +220,7 @@ optPortable="${7:-Y}"
 linkZsync=""
 gpgPass=""
 
-standard=(en-GB it ar zh-CN zh-TW fr de ja ko pt pt-BR es ru)
+standard=(nl en-GB fr de) #(en-GB it ar zh-CN zh-TW fr de ja ko pt pt-BR es ru)
 full=(af am ar as ast be bg bn-IN bn bo br brx bs ca-valencia ca cs cy da de dgo dz el en-GB en-ZA eo es et eu fa fi fr ga gd gl gu gug he hi hr hsb hu id is it ja ka kk km kmr kn ko kok ks lb lo lt lv mai mk ml mn mni mr my nb ne nl nn nr nso oc om or pa-IN pl pt-BR pt qtz ro ru rw sa-IN sat sd si sid sk sl sq sr-Latn sr ss st sv sw-TZ ta te tg th tn tr ts tt ug uk uz ve vec vi xh zh-CN zh-TW zu)
 
 if [[ $arch == *"x86-64"* ]] ; then

--- a/make_libreoffice_appimage
+++ b/make_libreoffice_appimage
@@ -388,7 +388,7 @@ if [[ $optHelp == *"Y"* ]] ; then
         helpStart="LibreOffice_${nrVersion}_Linux_${arch}_deb_helppack_"
     fi
     if [[ $language == *"standard"* ]] ; then
-         for element in ${standard[*]}; do
+         for element in ${standard[0]}; do  #help for 1st language only # WAS: for element in ${standard[*]}; do
             helpPackage="$helpStart$element.tar.gz"
             wget -c "$path$helpPackage"
          done


### PR DESCRIPTION
I added a new use case for your script. For multilingual people, likely the `standard` language selection does not include the languages they need, and the `full` set is quite large. It was quite simple to expand the `<single>` language option to a `<custom>` option, in the form of a comma separated list of language packs to include.

I found it convenient to allow the same possibility for the help language selection: I need help only in my main language.

I took care to keep the original workings of your script unchanged, up to naming the produced AppImage and zsync files. When more than 1 language is custom selected, I label them with the list of selected languages when up to 4 languages are chosen, else `custom`, so as to make the name of the AppImage file not too long. For the `help` label, it is an all or nothing scenario: it is set when the help argument is not N. I think that best fits the naming strategy in your current script version.

Your way of determining download sources for older versions of LibreOffice puzzled me. For pathVersion 3.* you download a `<single>` language pack from a different path, but not if the language  selection is `standard` or `full`. I don't know why, but I kept it that way. 