### PR TITLE
Improve support for version 7.*

### DIFF
--- a/make_libreoffice_appimage
+++ b/make_libreoffice_appimage
@@ -63,7 +63,7 @@ usage() {
 
 check() {   # This is not a complete, but only a limited sanity check of the inputs
     case $argv1 in
-        fresh|still|daily|3.*|4.*|5.*|6.*)
+        fresh|still|daily|3.*|4.*|5.*|6.*|7.*)
             # Do nothing, accepted!
             echo -e "\nBuilding LibreOffice AppImage from \"${argv1}\" channel or release:"
             ;;


### PR DESCRIPTION
When the first parameter is a specific 7.* version number (e.g. 7.2.4.1), the script did not work.

I propose this patch to correct the problem.
