### PR TITLE
Update make_libreoffice_appimage - LibreOffice versions

### DIFF
--- a/make_libreoffice_appimage
+++ b/make_libreoffice_appimage
@@ -63,7 +63,8 @@ usage() {
 
 check() {   # This is not a complete, but only a limited sanity check of the inputs
     case $argv1 in
-        fresh|still|daily|3.*|4.*|5.*|6.*|7.*)
+        fresh|still|daily|3.*|4.*|5.*|6.*|7.*|24.*|25.*|26.*|27.*|28.*|29.*)
+            # 2022.02 Accept new version naming scheme until 2029.
             # Do nothing, accepted!
             echo -e "\nBuilding LibreOffice AppImage from \"${argv1}\" channel or release:"
             ;;


### PR DESCRIPTION
Starting in February, 2024 new versions of LibreOffice will use the first two digits of the release year as the first two digits in the version number.